### PR TITLE
feat: Switch from passing build_script to passing build_cmd in the build workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,13 +32,13 @@ uploads the result to an S3 registry bucket.
 
 #### Inputs
 
-| Name             | Description                                                                | Type     | Default    | Required |
-| ---------------- | -------------------------------------------------------------------------- | -------- | ---------- | :------: |
-| `app_name`       | Name of the app, unique for the repo, kebab-cased                          | `string` | n/a        |   yes    |
-| `bucket_name`    | Name of the S3 registry bucket                                             | `string` | n/a        |   yes    |
-| `build_dir`      | Name of the directory where the production output is built                 | `string` | n/a        |   yes    |
-| `build_script`   | Name of the script in package.json used for building the production output | `string` | n/a        |   yes    |
-| `registry_scope` | Org scope for the GitHub Package Registry                                  | `string` | `@pleo-io` |    no    |
+| Name             | Description                                                | Type     | Default    | Required |
+| ---------------- | ---------------------------------------------------------- | -------- | ---------- | :------: |
+| `app_name`       | Name of the app, unique for the repo, kebab-cased          | `string` | n/a        |   yes    |
+| `bucket_name`    | Name of the S3 registry bucket                             | `string` | n/a        |   yes    |
+| `build_dir`      | Name of the directory where the production output is built | `string` | n/a        |   yes    |
+| `build_cmd`      | Command for building the production output                 | `string` | n/a        |   yes    |
+| `registry_scope` | Org scope for the GitHub Package Registry                  | `string` | `@pleo-io` |    no    |
 
 #### Secrets
 
@@ -67,7 +67,7 @@ build:
   secrets: inherit
   with:
     app_name: my-app
-    build_script: build:app
+    build_cmd: yarn build:app
     build_dir: dist
     bucket_name: my-registry-bucket
 ```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,9 +10,9 @@ criteria:
 
 - if your SPA is deployed to different environments with a varying config (like
   API keys, urls etc.), it needs to be able to build an environment agnostic
-  production version, i.e. a bundle without any baked-in configuration that
-  differs between environments. The way to accomplish this will vary depending
-  on the build tooling you use.
+  deploy bundle, i.e. a bundle which allows injecting a specific environment
+  configuration if necessary. The way to accomplish this will vary depending on
+  the build tooling you use.
 - if your SPA is deployed to different environments, you need to provide a
   command which can inject the config for the selected environment into the
   bundle. If provided, the deploy workflow will invoke that command before
@@ -32,13 +32,13 @@ uploads the result to an S3 registry bucket.
 
 #### Inputs
 
-| Name             | Description                                                | Type     | Default    | Required |
-| ---------------- | ---------------------------------------------------------- | -------- | ---------- | :------: |
-| `app_name`       | Name of the app, unique for the repo, kebab-cased          | `string` | n/a        |   yes    |
-| `bucket_name`    | Name of the S3 registry bucket                             | `string` | n/a        |   yes    |
-| `build_dir`      | Name of the directory where the production output is built | `string` | n/a        |   yes    |
-| `build_cmd`      | Command for building the production output                 | `string` | n/a        |   yes    |
-| `registry_scope` | Org scope for the GitHub Package Registry                  | `string` | `@pleo-io` |    no    |
+| Name             | Description                                       | Type     | Default    | Required |
+| ---------------- | ------------------------------------------------- | -------- | ---------- | :------: |
+| `app_name`       | Name of the app, unique for the repo, kebab-cased | `string` | n/a        |   yes    |
+| `bucket_name`    | Name of the S3 registry bucket                    | `string` | n/a        |   yes    |
+| `build_dir`      | Location of the deploy bundle after build         | `string` | n/a        |   yes    |
+| `build_cmd`      | Command for building the deploy bundle            | `string` | n/a        |   yes    |
+| `registry_scope` | Org scope for the GitHub Package Registry         | `string` | `@pleo-io` |    no    |
 
 #### Secrets
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,9 @@ on:
         description:
           "Name of the directory where the production output is built"
         type: string
-      build_script:
+      build_cmd:
         required: true
-        description:
-          "Script in package.json used for building the production output"
+        description: "Command for building the production output"
         type: string
       registry_scope:
         required: false
@@ -75,7 +74,7 @@ jobs:
 
       - name: Build
         if: steps.s3-cache.outputs.processed == 'false'
-        run: yarn ${{ inputs.build_script }}
+        run: ${{ inputs.build_cmd }}
 
       - name: Get Bundle S3 URI
         id: bundle-uri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,11 @@ on:
         type: string
       build_dir:
         required: true
-        description:
-          "Name of the directory where the production output is built"
+        description: "Location of the deploy bundle after build"
         type: string
       build_cmd:
         required: true
-        description: "Command for building the production output"
+        description: "Command for building the deploy bundle"
         type: string
       registry_scope:
         required: false


### PR DESCRIPTION
BREAKING CHANGE: The reusable build workflow now requires to pass a `build_cmd` input which is the entire command ran to build the deployable app bundle. This replaces the previous `build_script` input which assumed using a script defined in package.json