### PR TITLE
feat: Make "Post Preview URLs" action more generic

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -63,7 +63,7 @@ options when using the workflow.
 
 ```yml
 build:
-  uses: pleo-oss/pleo-spa-cicd/workflows/build.yml@v2
+  uses: pleo-oss/pleo-spa-cicd/workflows/build.yml@v6
   secrets: inherit
   with:
     app_name: my-app
@@ -113,7 +113,7 @@ options when using the workflow.
 
 ```yml
 deploy:
-  uses: pleo-oss/pleo-spa-cicd/workflows/deploy.yml@v2
+  uses: pleo-oss/pleo-spa-cicd/workflows/deploy.yml@v6
   needs: build
   secrets: inherit
   with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 name: Build
 
 on:
@@ -77,6 +79,13 @@ jobs:
         id: bundle-uri
         run: |
           echo "::set-output name=uri::s3://${{ inputs.bucket_name }}/bundles/${{ github.repository }}/${{ inputs.app_name }}/${{ steps.s3-cache.outputs.hash }}.tar.gz"
+
+      - uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_FRONTEND_REGISTRY }}
+          aws-secret-access-key:
+            ${{ secrets.AWS_SECRET_ACCESS_KEY_FRONTEND_REGISTRY }}
+          aws-region: eu-west-1
 
       - name: Compress & Upload Bundle
         if: steps.s3-cache.outputs.processed == 'false'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 name: Deploy
 
 on:
@@ -63,6 +65,8 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: ${{ inputs.registry_scope }}
 
+      # For feature preview deployments we're using the permalink as the deploy URL for the GitHub deployment
+      # For deployments on the default branch we're using the domain name passed via inputs.
       - name: Get Deployment URL
         id: deployment-url
         run: |
@@ -109,17 +113,21 @@ jobs:
            --exclude "static/*"
 
       - name: Update Cursor File
-        uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v1.3.1
+        id: cursor-update
+        uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v6
         with:
           bucket_name: ${{ inputs.bucket_name }}
 
       - name: Update PR Description
-        uses: pleo-oss/pleo-spa-cicd/actions/post-preview-urls@v1.3.1
+        uses: pleo-oss/pleo-spa-cicd/actions/post-preview-urls@v6
         if: github.event_name == 'pull_request'
         with:
-          domain: ${{ inputs.domain_name }}
           app_name: ${{ inputs.app_name }}
-          permalink: ${{ steps.deployment-url.outputs.url }}
+          links: |
+            [
+              {"name": "Latest", "url": "https://${{ steps.cursor-update.outputs.branch_label }}.${{ inputs.domain_name }}"},
+              {"name": "Current Permalink", "url": "${{ steps.deployment-url.outputs.url }}"}
+            ]
 
       - name: Upload Deployed Bundle as Artifact
         uses: actions/upload-artifact@v3.1.0

--- a/actions/README.md
+++ b/actions/README.md
@@ -7,10 +7,11 @@ which help implementing a CI/CD pipeline described in this repository.
 
 ## Actions
 
-| Name                                     | Description                                                            |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| [cursor-deploy](./cursor-deploy)         | Performs a deployment by updating a cursor file in an S3 bucket.       |
-| [post-preview-urls](./post-preview-urls) | Update PR description with the links to the latest preview deployment. |
+| Name                                                     | Description                                                                              |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --- |
+| [cursor-deploy](./cursor-deploy)                         | Performs a deployment by updating a cursor file in an S3 bucket.                         |
+| [post-preview-urls](./post-preview-urls)                 | Update PR description with the links to the latest preview deployment.                   |     |
+| [translation-cursor-deploy](./translation-cursor-deploy) | Performs a deployment by updating a cursor file in an S3 bucket - used for translations. |
 
 ## Contributing
 

--- a/actions/cursor-deploy/README.md
+++ b/actions/cursor-deploy/README.md
@@ -35,9 +35,10 @@ action in a step prior to running this action to ensure that's the case.
 
 ## Outputs
 
-| parameter | description                               |
-| --------- | ----------------------------------------- |
-| tree_hash | The tree hash of the performed deployment |
+| parameter    | description                                                                    |
+| ------------ | ------------------------------------------------------------------------------ |
+| tree_hash    | The tree hash of the performed deployment                                      |
+| branch_label | The branch label used for deployment (e.g. the hostname label for preview URL) |
 
 <!-- action-docs-outputs -->
 
@@ -46,7 +47,7 @@ action in a step prior to running this action to ensure that's the case.
 ```yml
 - name: Update the cursor file
   id: deployment
-  uses: 'pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v1'
+  uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v6
   with:
       bucket_name: my-s3-bucket
 ```
@@ -82,7 +83,7 @@ jobs:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             - name: Update Cursor File
-              uses: 'pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v1'
+              uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v6
               with:
                   bucket_name: my-origin-bucket
                   rollback_commit_hash: ${{ github.event.inputs.sha }}
@@ -106,7 +107,7 @@ jobs:
                   aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
             - name: Update Cursor File
-              uses: 'pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v1'
+              uses: pleo-oss/pleo-spa-cicd/actions/cursor-deploy@v6
               with:
                   bucket_name: my-origin-bucket
                   deploy_mode: update

--- a/actions/cursor-deploy/action.yml
+++ b/actions/cursor-deploy/action.yml
@@ -16,6 +16,8 @@ inputs:
 outputs:
     tree_hash:
         description: The tree hash of the performed deployment
+    branch_label:
+        description: The branch label used for deployment (e.g. the hostname label for preview URL)
 runs:
     using: 'node16'
     main: 'dist/main/index.js'

--- a/actions/cursor-deploy/dist/main/index.js
+++ b/actions/cursor-deploy/dist/main/index.js
@@ -140,6 +140,7 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
+const uuid_1 = __nccwpck_require__(5840);
 const oidc_utils_1 = __nccwpck_require__(8041);
 /**
  * The code to exit an action
@@ -169,7 +170,14 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
+        if (name.includes(delimiter)) {
+            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+        }
+        if (convertedVal.includes(delimiter)) {
+            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+        }
         const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
         file_command_1.issueCommand('ENV', commandValue);
     }
@@ -8284,6 +8292,652 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
+/***/ 5840:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "v1", ({
+  enumerable: true,
+  get: function () {
+    return _v.default;
+  }
+}));
+Object.defineProperty(exports, "v3", ({
+  enumerable: true,
+  get: function () {
+    return _v2.default;
+  }
+}));
+Object.defineProperty(exports, "v4", ({
+  enumerable: true,
+  get: function () {
+    return _v3.default;
+  }
+}));
+Object.defineProperty(exports, "v5", ({
+  enumerable: true,
+  get: function () {
+    return _v4.default;
+  }
+}));
+Object.defineProperty(exports, "NIL", ({
+  enumerable: true,
+  get: function () {
+    return _nil.default;
+  }
+}));
+Object.defineProperty(exports, "version", ({
+  enumerable: true,
+  get: function () {
+    return _version.default;
+  }
+}));
+Object.defineProperty(exports, "validate", ({
+  enumerable: true,
+  get: function () {
+    return _validate.default;
+  }
+}));
+Object.defineProperty(exports, "stringify", ({
+  enumerable: true,
+  get: function () {
+    return _stringify.default;
+  }
+}));
+Object.defineProperty(exports, "parse", ({
+  enumerable: true,
+  get: function () {
+    return _parse.default;
+  }
+}));
+
+var _v = _interopRequireDefault(__nccwpck_require__(8628));
+
+var _v2 = _interopRequireDefault(__nccwpck_require__(6409));
+
+var _v3 = _interopRequireDefault(__nccwpck_require__(5122));
+
+var _v4 = _interopRequireDefault(__nccwpck_require__(9120));
+
+var _nil = _interopRequireDefault(__nccwpck_require__(5332));
+
+var _version = _interopRequireDefault(__nccwpck_require__(1595));
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+var _parse = _interopRequireDefault(__nccwpck_require__(2746));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/***/ }),
+
+/***/ 4569:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function md5(bytes) {
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
+  }
+
+  return _crypto.default.createHash('md5').update(bytes).digest();
+}
+
+var _default = md5;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 5332:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+var _default = '00000000-0000-0000-0000-000000000000';
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 2746:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function parse(uuid) {
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  let v;
+  const arr = new Uint8Array(16); // Parse ########-....-....-....-............
+
+  arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
+  arr[1] = v >>> 16 & 0xff;
+  arr[2] = v >>> 8 & 0xff;
+  arr[3] = v & 0xff; // Parse ........-####-....-....-............
+
+  arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
+  arr[5] = v & 0xff; // Parse ........-....-####-....-............
+
+  arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
+  arr[7] = v & 0xff; // Parse ........-....-....-####-............
+
+  arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
+  arr[9] = v & 0xff; // Parse ........-....-....-....-############
+  // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+
+  arr[10] = (v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000 & 0xff;
+  arr[11] = v / 0x100000000 & 0xff;
+  arr[12] = v >>> 24 & 0xff;
+  arr[13] = v >>> 16 & 0xff;
+  arr[14] = v >>> 8 & 0xff;
+  arr[15] = v & 0xff;
+  return arr;
+}
+
+var _default = parse;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 814:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+var _default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 807:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = rng;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
+
+let poolPtr = rnds8Pool.length;
+
+function rng() {
+  if (poolPtr > rnds8Pool.length - 16) {
+    _crypto.default.randomFillSync(rnds8Pool);
+
+    poolPtr = 0;
+  }
+
+  return rnds8Pool.slice(poolPtr, poolPtr += 16);
+}
+
+/***/ }),
+
+/***/ 5274:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function sha1(bytes) {
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
+  }
+
+  return _crypto.default.createHash('sha1').update(bytes).digest();
+}
+
+var _default = sha1;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 8950:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Convert array of 16 byte values to UUID string format of the form:
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+ */
+const byteToHex = [];
+
+for (let i = 0; i < 256; ++i) {
+  byteToHex.push((i + 0x100).toString(16).substr(1));
+}
+
+function stringify(arr, offset = 0) {
+  // Note: Be careful editing this code!  It's been tuned for performance
+  // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
+  const uuid = (byteToHex[arr[offset + 0]] + byteToHex[arr[offset + 1]] + byteToHex[arr[offset + 2]] + byteToHex[arr[offset + 3]] + '-' + byteToHex[arr[offset + 4]] + byteToHex[arr[offset + 5]] + '-' + byteToHex[arr[offset + 6]] + byteToHex[arr[offset + 7]] + '-' + byteToHex[arr[offset + 8]] + byteToHex[arr[offset + 9]] + '-' + byteToHex[arr[offset + 10]] + byteToHex[arr[offset + 11]] + byteToHex[arr[offset + 12]] + byteToHex[arr[offset + 13]] + byteToHex[arr[offset + 14]] + byteToHex[arr[offset + 15]]).toLowerCase(); // Consistency check for valid UUID.  If this throws, it's likely due to one
+  // of the following:
+  // - One or more input array values don't map to a hex octet (leading to
+  // "undefined" in the uuid)
+  // - Invalid input values for the RFC `version` or `variant` fields
+
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Stringified UUID is invalid');
+  }
+
+  return uuid;
+}
+
+var _default = stringify;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 8628:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// **`v1()` - Generate time-based UUID**
+//
+// Inspired by https://github.com/LiosK/UUID.js
+// and http://docs.python.org/library/uuid.html
+let _nodeId;
+
+let _clockseq; // Previous uuid creation time
+
+
+let _lastMSecs = 0;
+let _lastNSecs = 0; // See https://github.com/uuidjs/uuid for API details
+
+function v1(options, buf, offset) {
+  let i = buf && offset || 0;
+  const b = buf || new Array(16);
+  options = options || {};
+  let node = options.node || _nodeId;
+  let clockseq = options.clockseq !== undefined ? options.clockseq : _clockseq; // node and clockseq need to be initialized to random values if they're not
+  // specified.  We do this lazily to minimize issues related to insufficient
+  // system entropy.  See #189
+
+  if (node == null || clockseq == null) {
+    const seedBytes = options.random || (options.rng || _rng.default)();
+
+    if (node == null) {
+      // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
+      node = _nodeId = [seedBytes[0] | 0x01, seedBytes[1], seedBytes[2], seedBytes[3], seedBytes[4], seedBytes[5]];
+    }
+
+    if (clockseq == null) {
+      // Per 4.2.2, randomize (14 bit) clockseq
+      clockseq = _clockseq = (seedBytes[6] << 8 | seedBytes[7]) & 0x3fff;
+    }
+  } // UUID timestamps are 100 nano-second units since the Gregorian epoch,
+  // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
+  // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
+  // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
+
+
+  let msecs = options.msecs !== undefined ? options.msecs : Date.now(); // Per 4.2.1.2, use count of uuid's generated during the current clock
+  // cycle to simulate higher resolution clock
+
+  let nsecs = options.nsecs !== undefined ? options.nsecs : _lastNSecs + 1; // Time since last uuid creation (in msecs)
+
+  const dt = msecs - _lastMSecs + (nsecs - _lastNSecs) / 10000; // Per 4.2.1.2, Bump clockseq on clock regression
+
+  if (dt < 0 && options.clockseq === undefined) {
+    clockseq = clockseq + 1 & 0x3fff;
+  } // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
+  // time interval
+
+
+  if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === undefined) {
+    nsecs = 0;
+  } // Per 4.2.1.2 Throw error if too many uuids are requested
+
+
+  if (nsecs >= 10000) {
+    throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+  }
+
+  _lastMSecs = msecs;
+  _lastNSecs = nsecs;
+  _clockseq = clockseq; // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
+
+  msecs += 12219292800000; // `time_low`
+
+  const tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
+  b[i++] = tl >>> 24 & 0xff;
+  b[i++] = tl >>> 16 & 0xff;
+  b[i++] = tl >>> 8 & 0xff;
+  b[i++] = tl & 0xff; // `time_mid`
+
+  const tmh = msecs / 0x100000000 * 10000 & 0xfffffff;
+  b[i++] = tmh >>> 8 & 0xff;
+  b[i++] = tmh & 0xff; // `time_high_and_version`
+
+  b[i++] = tmh >>> 24 & 0xf | 0x10; // include version
+
+  b[i++] = tmh >>> 16 & 0xff; // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
+
+  b[i++] = clockseq >>> 8 | 0x80; // `clock_seq_low`
+
+  b[i++] = clockseq & 0xff; // `node`
+
+  for (let n = 0; n < 6; ++n) {
+    b[i + n] = node[n];
+  }
+
+  return buf || (0, _stringify.default)(b);
+}
+
+var _default = v1;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 6409:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _v = _interopRequireDefault(__nccwpck_require__(5998));
+
+var _md = _interopRequireDefault(__nccwpck_require__(4569));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const v3 = (0, _v.default)('v3', 0x30, _md.default);
+var _default = v3;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 5998:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = _default;
+exports.URL = exports.DNS = void 0;
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+var _parse = _interopRequireDefault(__nccwpck_require__(2746));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function stringToBytes(str) {
+  str = unescape(encodeURIComponent(str)); // UTF8 escape
+
+  const bytes = [];
+
+  for (let i = 0; i < str.length; ++i) {
+    bytes.push(str.charCodeAt(i));
+  }
+
+  return bytes;
+}
+
+const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+exports.DNS = DNS;
+const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+exports.URL = URL;
+
+function _default(name, version, hashfunc) {
+  function generateUUID(value, namespace, buf, offset) {
+    if (typeof value === 'string') {
+      value = stringToBytes(value);
+    }
+
+    if (typeof namespace === 'string') {
+      namespace = (0, _parse.default)(namespace);
+    }
+
+    if (namespace.length !== 16) {
+      throw TypeError('Namespace must be array-like (16 iterable integer values, 0-255)');
+    } // Compute hash of namespace and value, Per 4.3
+    // Future: Use spread syntax when supported on all platforms, e.g. `bytes =
+    // hashfunc([...namespace, ... value])`
+
+
+    let bytes = new Uint8Array(16 + value.length);
+    bytes.set(namespace);
+    bytes.set(value, namespace.length);
+    bytes = hashfunc(bytes);
+    bytes[6] = bytes[6] & 0x0f | version;
+    bytes[8] = bytes[8] & 0x3f | 0x80;
+
+    if (buf) {
+      offset = offset || 0;
+
+      for (let i = 0; i < 16; ++i) {
+        buf[offset + i] = bytes[i];
+      }
+
+      return buf;
+    }
+
+    return (0, _stringify.default)(bytes);
+  } // Function#name is not settable on some platforms (#270)
+
+
+  try {
+    generateUUID.name = name; // eslint-disable-next-line no-empty
+  } catch (err) {} // For CommonJS default export support
+
+
+  generateUUID.DNS = DNS;
+  generateUUID.URL = URL;
+  return generateUUID;
+}
+
+/***/ }),
+
+/***/ 5122:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function v4(options, buf, offset) {
+  options = options || {};
+
+  const rnds = options.random || (options.rng || _rng.default)(); // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+
+
+  rnds[6] = rnds[6] & 0x0f | 0x40;
+  rnds[8] = rnds[8] & 0x3f | 0x80; // Copy bytes to buffer, if provided
+
+  if (buf) {
+    offset = offset || 0;
+
+    for (let i = 0; i < 16; ++i) {
+      buf[offset + i] = rnds[i];
+    }
+
+    return buf;
+  }
+
+  return (0, _stringify.default)(rnds);
+}
+
+var _default = v4;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 9120:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _v = _interopRequireDefault(__nccwpck_require__(5998));
+
+var _sha = _interopRequireDefault(__nccwpck_require__(5274));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const v5 = (0, _v.default)('v5', 0x50, _sha.default);
+var _default = v5;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 6900:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _regex = _interopRequireDefault(__nccwpck_require__(814));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function validate(uuid) {
+  return typeof uuid === 'string' && _regex.default.test(uuid);
+}
+
+var _default = validate;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 1595:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function version(uuid) {
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  return parseInt(uuid.substr(14, 1), 16);
+}
+
+var _default = version;
+exports["default"] = _default;
+
+/***/ }),
+
 /***/ 4886:
 /***/ ((module) => {
 
@@ -10330,7 +10984,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.cursorDeploy = void 0;
+exports.branchNameToHostnameLabel = exports.cursorDeploy = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const utils_1 = __nccwpck_require__(691);
@@ -10347,46 +11001,47 @@ const deployModes = ['default', 'rollback', 'unblock'];
         ref: (_c = (_b = (_a = github.context.payload) === null || _a === void 0 ? void 0 : _a.pull_request) === null || _b === void 0 ? void 0 : _b.head.ref) !== null && _c !== void 0 ? _c : github.context.ref
     });
     core.setOutput('tree_hash', output.treeHash);
+    core.setOutput('branch_label', output.branchLabel);
 }));
 function cursorDeploy({ ref, bucket, deployModeInput, rollbackCommitHash }) {
     return __awaiter(this, void 0, void 0, function* () {
         const deployMode = getDeployMode(deployModeInput);
-        const branchName = (0, utils_1.getSanitizedBranchName)(ref);
+        const branchLabel = branchNameToHostnameLabel(ref);
         const treeHash = yield getDeploymentHash(deployMode, rollbackCommitHash);
-        const rollbackKey = `rollbacks/${branchName}`;
-        const deployKey = `deploys/${branchName}`;
+        const rollbackKey = `rollbacks/${branchLabel}`;
+        const deployKey = `deploys/${branchLabel}`;
         if (deployMode === 'default' || deployMode === 'unblock') {
             const rollbackFileExists = yield (0, utils_1.fileExistsInS3)({ bucket, key: rollbackKey });
             // If we're doing a regular deployment, we need to make sure there isn't an active
             // rollback for the branch we're deploying. Active rollback prevents automatic
             // deployments and requires an explicit unblocking deployment to resume them.
             if (deployMode === 'default' && rollbackFileExists) {
-                throw new Error(`${branchName} is currently blocked due to an active rollback.`);
+                throw new Error(`${branchLabel} is currently blocked due to an active rollback.`);
             }
             // If we're unblocking a branch after a rollback, it only makes sense if there is an
             // active rollback
             if (deployMode === 'unblock' && !rollbackFileExists) {
-                throw new Error(`${branchName} does not have an active rollback, you can't unblock.`);
+                throw new Error(`${branchLabel} does not have an active rollback, you can't unblock.`);
             }
         }
         // Perform the deployment by updating the cursor file for the current branch to point
         // to the desired tree hash
-        yield (0, utils_1.writeLineToFile)({ text: treeHash, path: branchName });
-        yield (0, utils_1.copyFileToS3)({ path: branchName, bucket, key: deployKey });
-        core.info(`Tree hash ${treeHash} is now the active deployment for ${branchName}.`);
+        yield (0, utils_1.writeLineToFile)({ text: treeHash, path: branchLabel });
+        yield (0, utils_1.copyFileToS3)({ path: branchLabel, bucket, key: deployKey });
+        core.info(`Tree hash ${treeHash} is now the active deployment for ${branchLabel}.`);
         // If we're doing a rollback deployment we create a rollback file that blocks any following
         // deployments from going through.
         if (deployMode === 'rollback') {
-            yield (0, utils_1.copyFileToS3)({ path: branchName, bucket, key: rollbackKey });
-            core.info(`${branchName} marked as rolled back, automatic deploys paused.`);
+            yield (0, utils_1.copyFileToS3)({ path: branchLabel, bucket, key: rollbackKey });
+            core.info(`${branchLabel} marked as rolled back, automatic deploys paused.`);
         }
         // If we're doing an unblock deployment, we delete the rollback file to allow the following
         // deployments to go through
         if (deployMode === 'unblock') {
             yield (0, utils_1.removeFileFromS3)({ bucket, key: rollbackKey });
-            core.info(`${branchName} has automatic deploys resumed.`);
+            core.info(`${branchLabel} has automatic deploys resumed.`);
         }
-        return { treeHash };
+        return { treeHash, branchLabel };
     });
 }
 exports.cursorDeploy = cursorDeploy;
@@ -10435,6 +11090,15 @@ function getDeploymentHash(deployMode, rollbackCommitHash) {
         return treeHash;
     });
 }
+function branchNameToHostnameLabel(ref) {
+    var _a;
+    const hostnameLabel = (_a = ref === null || ref === void 0 ? void 0 : ref.split('refs/heads/').pop()) === null || _a === void 0 ? void 0 : _a.replace(/[^\w]/gi, '-').replace(/-{2,}/gi, '-').toLowerCase().slice(0, 60).trim();
+    if (!hostnameLabel) {
+        throw new Error('Could not get a valid hostname label from branch name');
+    }
+    return hostnameLabel;
+}
+exports.branchNameToHostnameLabel = branchNameToHostnameLabel;
 
 
 /***/ }),
@@ -10477,7 +11141,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.isHeadAncestor = exports.getSanitizedBranchName = exports.runAction = exports.removeFileFromS3 = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.execIsSuccessful = exports.execReadOutput = void 0;
+exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.isHeadAncestor = exports.runAction = exports.removeFileFromS3 = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.execIsSuccessful = exports.execReadOutput = void 0;
 const exec_1 = __nccwpck_require__(1514);
 const core = __importStar(__nccwpck_require__(2186));
 /**
@@ -10591,22 +11255,6 @@ function runAction(action) {
 }
 exports.runAction = runAction;
 /**
- * Retrieve and convert the current git branch name to a string that is safe
- * for use as a S3 file key and a URL segment
- * @returns branchName
- */
-function getSanitizedBranchName(ref) {
-    var _a;
-    const branchName = (_a = ref
-        .split('refs/heads/')
-        .pop()) === null || _a === void 0 ? void 0 : _a.replace(/[^\w]/gi, '-').replace(/-{2,}/gi, '-').toLowerCase().slice(0, 60).trim();
-    if (!branchName) {
-        throw new Error('Invalid context, could not calculate sanitized branch name');
-    }
-    return branchName;
-}
-exports.getSanitizedBranchName = getSanitizedBranchName;
-/**
  * Validate if the passed git commit hash is present on the current branch
  * @param commitHash - commit hash to validate
  * @returns isHeadAncestor
@@ -10665,6 +11313,14 @@ module.exports = require("assert");
 
 "use strict";
 module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 6113:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("crypto");
 
 /***/ }),
 

--- a/actions/cursor-deploy/main.test.ts
+++ b/actions/cursor-deploy/main.test.ts
@@ -313,26 +313,26 @@ describe(`Cursor Deploy Action`, () => {
 })
 
 describe('Branch Sanitize - branchNameToHostnameLabel', () => {
-    test(`sanitizes a full git ref into a DNS-ready string`, async () => {
+    it(`sanitizes a full git ref into a DNS-ready string`, async () => {
         const output = branchNameToHostnameLabel('refs/heads/hello/world')
         expect(output).toBe('hello-world')
     })
 
-    test(`replaces all non-word characters with a dash`, async () => {
+    it(`replaces all non-word characters with a dash`, async () => {
         const output = branchNameToHostnameLabel(
             'refs/heads/hello/world-100%_ready,for.this!here:it"a)b(c{d}e'
         )
         expect(output).toBe('hello-world-100-_ready-for-this-here-it-a-b-c-d-e')
     })
 
-    test(`removes multiple dashes in a row`, async () => {
+    it(`removes multiple dashes in a row`, async () => {
         const output = branchNameToHostnameLabel(
             'refs/heads/hello/my-very-weird_branch-100%%%-original'
         )
         expect(output).toBe('hello-my-very-weird_branch-100-original')
     })
 
-    test(`caps the length of the sanitized name to 60 characters`, async () => {
+    it(`caps the length of the sanitized name to 60 characters`, async () => {
         const output = branchNameToHostnameLabel(
             'refs/heads/hello/my-very-weird_branch-100-original-whoooohoooooo-lets-do_it'
         )

--- a/actions/jest.config.js
+++ b/actions/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
     preset: 'ts-jest',
-    testEnvironment: 'node'
+    testEnvironment: 'node',
+    clearMocks: true
 }

--- a/actions/package.json
+++ b/actions/package.json
@@ -3,19 +3,19 @@
     "name": "pleo-spa-cdicd-actions",
     "version": "0.0.0",
     "dependencies": {
-        "@actions/core": "1.9.0",
+        "@actions/core": "1.9.1",
         "@actions/exec": "1.1.1",
         "@actions/github": "5.0.3"
     },
     "devDependencies": {
         "@types/common-tags": "^1.8.1",
-        "@types/jest": "^28.1.6",
+        "@types/jest": "^28.1.7",
         "@vercel/ncc": "0.34.0",
         "action-docs": "^1.0.4",
         "common-tags": "^1.8.2",
         "jest": "28.1.3",
         "prettier": "^2.7.1",
-        "ts-jest": "^28.0.7",
+        "ts-jest": "^28.0.8",
         "typescript": "4.7.4"
     }
 }

--- a/actions/post-preview-urls/README.md
+++ b/actions/post-preview-urls/README.md
@@ -16,22 +16,26 @@ Append the URLs for branch app and storybook preview deployments to the PR descr
 
 ```yml
 - name: Update PR Description
-  uses: pleo-oss/pleo-spa-cicd/actions/post-preview-urls@v1
+  uses: pleo-oss/pleo-spa-cicd/actions/post-preview-urls@v6
   with:
-      domain: app.example.com
-      permalink: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
+      app_name: My App
+      links: |
+          [
+            {"name": "Latest", "url": "https://${{ steps.branch-hostname.outputs.label }}.${{ inputs.domain_name }}"},
+            {"name": "Current Permalink", "url": "${{ steps.deployment-url.outputs.url }}"}
+          ]
 ```
 
 <!-- action-docs-inputs -->
 
 ## Inputs
 
-| parameter | description                                     | required | default             |
-| --------- | ----------------------------------------------- | -------- | ------------------- |
-| token     | GitHub token used to update the PR description  | `false`  | ${{ github.token }} |
-| domain    | The domain for the app deployments              | `true`   |                     |
-| permalink | The permalink to the current preview deployment | `false`  |                     |
-| app_name  | The name displayed in the link section title    | `false`  | 🤖 App              |
+| parameter | description                                                                                      | required | default             |
+| --------- | ------------------------------------------------------------------------------------------------ | -------- | ------------------- |
+| token     | GitHub token used to update the PR description                                                   | `false`  | ${{ github.token }} |
+| links     | JSON specification of links to post to the PR description (`Array<{name: string, url: string}>`) | `true`   |                     |
+| as_labels | If true, the URL is not displayed and all links are rendered as a comma-separated list           | `false`  | false               |
+| app_name  | The name displayed in the link section title                                                     | `false`  | 🤖 App              |
 
 <!-- action-docs-inputs -->
 

--- a/actions/post-preview-urls/action.yml
+++ b/actions/post-preview-urls/action.yml
@@ -7,12 +7,16 @@ inputs:
         description: GitHub token used to update the PR description
         required: false
         default: ${{ github.token }}
-    domain:
-        description: The domain for the app deployments
+    links:
+        description:
+            'JSON specification of links to post to the PR description (`Array<{name: string, url:
+            string}>`)'
         required: true
-    permalink:
-        description: The permalink to the current preview deployment
+    as_labels:
+        description:
+            If true, the URL is not displayed and all links are rendered as a comma-separated list
         required: false
+        default: 'false'
     app_name:
         description: The name displayed in the link section title
         required: false

--- a/actions/post-preview-urls/dist/main/index.js
+++ b/actions/post-preview-urls/dist/main/index.js
@@ -140,6 +140,7 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
 const os = __importStar(__nccwpck_require__(2037));
 const path = __importStar(__nccwpck_require__(1017));
+const uuid_1 = __nccwpck_require__(5840);
 const oidc_utils_1 = __nccwpck_require__(8041);
 /**
  * The code to exit an action
@@ -169,7 +170,14 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
+        if (name.includes(delimiter)) {
+            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+        }
+        if (convertedVal.includes(delimiter)) {
+            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+        }
         const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
         file_command_1.issueCommand('ENV', commandValue);
     }
@@ -8284,6 +8292,652 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
+/***/ 5840:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "v1", ({
+  enumerable: true,
+  get: function () {
+    return _v.default;
+  }
+}));
+Object.defineProperty(exports, "v3", ({
+  enumerable: true,
+  get: function () {
+    return _v2.default;
+  }
+}));
+Object.defineProperty(exports, "v4", ({
+  enumerable: true,
+  get: function () {
+    return _v3.default;
+  }
+}));
+Object.defineProperty(exports, "v5", ({
+  enumerable: true,
+  get: function () {
+    return _v4.default;
+  }
+}));
+Object.defineProperty(exports, "NIL", ({
+  enumerable: true,
+  get: function () {
+    return _nil.default;
+  }
+}));
+Object.defineProperty(exports, "version", ({
+  enumerable: true,
+  get: function () {
+    return _version.default;
+  }
+}));
+Object.defineProperty(exports, "validate", ({
+  enumerable: true,
+  get: function () {
+    return _validate.default;
+  }
+}));
+Object.defineProperty(exports, "stringify", ({
+  enumerable: true,
+  get: function () {
+    return _stringify.default;
+  }
+}));
+Object.defineProperty(exports, "parse", ({
+  enumerable: true,
+  get: function () {
+    return _parse.default;
+  }
+}));
+
+var _v = _interopRequireDefault(__nccwpck_require__(8628));
+
+var _v2 = _interopRequireDefault(__nccwpck_require__(6409));
+
+var _v3 = _interopRequireDefault(__nccwpck_require__(5122));
+
+var _v4 = _interopRequireDefault(__nccwpck_require__(9120));
+
+var _nil = _interopRequireDefault(__nccwpck_require__(5332));
+
+var _version = _interopRequireDefault(__nccwpck_require__(1595));
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+var _parse = _interopRequireDefault(__nccwpck_require__(2746));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/***/ }),
+
+/***/ 4569:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function md5(bytes) {
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
+  }
+
+  return _crypto.default.createHash('md5').update(bytes).digest();
+}
+
+var _default = md5;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 5332:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+var _default = '00000000-0000-0000-0000-000000000000';
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 2746:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function parse(uuid) {
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  let v;
+  const arr = new Uint8Array(16); // Parse ########-....-....-....-............
+
+  arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
+  arr[1] = v >>> 16 & 0xff;
+  arr[2] = v >>> 8 & 0xff;
+  arr[3] = v & 0xff; // Parse ........-####-....-....-............
+
+  arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
+  arr[5] = v & 0xff; // Parse ........-....-####-....-............
+
+  arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
+  arr[7] = v & 0xff; // Parse ........-....-....-####-............
+
+  arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
+  arr[9] = v & 0xff; // Parse ........-....-....-....-############
+  // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+
+  arr[10] = (v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000 & 0xff;
+  arr[11] = v / 0x100000000 & 0xff;
+  arr[12] = v >>> 24 & 0xff;
+  arr[13] = v >>> 16 & 0xff;
+  arr[14] = v >>> 8 & 0xff;
+  arr[15] = v & 0xff;
+  return arr;
+}
+
+var _default = parse;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 814:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+var _default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 807:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = rng;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
+
+let poolPtr = rnds8Pool.length;
+
+function rng() {
+  if (poolPtr > rnds8Pool.length - 16) {
+    _crypto.default.randomFillSync(rnds8Pool);
+
+    poolPtr = 0;
+  }
+
+  return rnds8Pool.slice(poolPtr, poolPtr += 16);
+}
+
+/***/ }),
+
+/***/ 5274:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(6113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function sha1(bytes) {
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
+  }
+
+  return _crypto.default.createHash('sha1').update(bytes).digest();
+}
+
+var _default = sha1;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 8950:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Convert array of 16 byte values to UUID string format of the form:
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+ */
+const byteToHex = [];
+
+for (let i = 0; i < 256; ++i) {
+  byteToHex.push((i + 0x100).toString(16).substr(1));
+}
+
+function stringify(arr, offset = 0) {
+  // Note: Be careful editing this code!  It's been tuned for performance
+  // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
+  const uuid = (byteToHex[arr[offset + 0]] + byteToHex[arr[offset + 1]] + byteToHex[arr[offset + 2]] + byteToHex[arr[offset + 3]] + '-' + byteToHex[arr[offset + 4]] + byteToHex[arr[offset + 5]] + '-' + byteToHex[arr[offset + 6]] + byteToHex[arr[offset + 7]] + '-' + byteToHex[arr[offset + 8]] + byteToHex[arr[offset + 9]] + '-' + byteToHex[arr[offset + 10]] + byteToHex[arr[offset + 11]] + byteToHex[arr[offset + 12]] + byteToHex[arr[offset + 13]] + byteToHex[arr[offset + 14]] + byteToHex[arr[offset + 15]]).toLowerCase(); // Consistency check for valid UUID.  If this throws, it's likely due to one
+  // of the following:
+  // - One or more input array values don't map to a hex octet (leading to
+  // "undefined" in the uuid)
+  // - Invalid input values for the RFC `version` or `variant` fields
+
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Stringified UUID is invalid');
+  }
+
+  return uuid;
+}
+
+var _default = stringify;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 8628:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// **`v1()` - Generate time-based UUID**
+//
+// Inspired by https://github.com/LiosK/UUID.js
+// and http://docs.python.org/library/uuid.html
+let _nodeId;
+
+let _clockseq; // Previous uuid creation time
+
+
+let _lastMSecs = 0;
+let _lastNSecs = 0; // See https://github.com/uuidjs/uuid for API details
+
+function v1(options, buf, offset) {
+  let i = buf && offset || 0;
+  const b = buf || new Array(16);
+  options = options || {};
+  let node = options.node || _nodeId;
+  let clockseq = options.clockseq !== undefined ? options.clockseq : _clockseq; // node and clockseq need to be initialized to random values if they're not
+  // specified.  We do this lazily to minimize issues related to insufficient
+  // system entropy.  See #189
+
+  if (node == null || clockseq == null) {
+    const seedBytes = options.random || (options.rng || _rng.default)();
+
+    if (node == null) {
+      // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
+      node = _nodeId = [seedBytes[0] | 0x01, seedBytes[1], seedBytes[2], seedBytes[3], seedBytes[4], seedBytes[5]];
+    }
+
+    if (clockseq == null) {
+      // Per 4.2.2, randomize (14 bit) clockseq
+      clockseq = _clockseq = (seedBytes[6] << 8 | seedBytes[7]) & 0x3fff;
+    }
+  } // UUID timestamps are 100 nano-second units since the Gregorian epoch,
+  // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
+  // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
+  // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
+
+
+  let msecs = options.msecs !== undefined ? options.msecs : Date.now(); // Per 4.2.1.2, use count of uuid's generated during the current clock
+  // cycle to simulate higher resolution clock
+
+  let nsecs = options.nsecs !== undefined ? options.nsecs : _lastNSecs + 1; // Time since last uuid creation (in msecs)
+
+  const dt = msecs - _lastMSecs + (nsecs - _lastNSecs) / 10000; // Per 4.2.1.2, Bump clockseq on clock regression
+
+  if (dt < 0 && options.clockseq === undefined) {
+    clockseq = clockseq + 1 & 0x3fff;
+  } // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
+  // time interval
+
+
+  if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === undefined) {
+    nsecs = 0;
+  } // Per 4.2.1.2 Throw error if too many uuids are requested
+
+
+  if (nsecs >= 10000) {
+    throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+  }
+
+  _lastMSecs = msecs;
+  _lastNSecs = nsecs;
+  _clockseq = clockseq; // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
+
+  msecs += 12219292800000; // `time_low`
+
+  const tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
+  b[i++] = tl >>> 24 & 0xff;
+  b[i++] = tl >>> 16 & 0xff;
+  b[i++] = tl >>> 8 & 0xff;
+  b[i++] = tl & 0xff; // `time_mid`
+
+  const tmh = msecs / 0x100000000 * 10000 & 0xfffffff;
+  b[i++] = tmh >>> 8 & 0xff;
+  b[i++] = tmh & 0xff; // `time_high_and_version`
+
+  b[i++] = tmh >>> 24 & 0xf | 0x10; // include version
+
+  b[i++] = tmh >>> 16 & 0xff; // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
+
+  b[i++] = clockseq >>> 8 | 0x80; // `clock_seq_low`
+
+  b[i++] = clockseq & 0xff; // `node`
+
+  for (let n = 0; n < 6; ++n) {
+    b[i + n] = node[n];
+  }
+
+  return buf || (0, _stringify.default)(b);
+}
+
+var _default = v1;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 6409:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _v = _interopRequireDefault(__nccwpck_require__(5998));
+
+var _md = _interopRequireDefault(__nccwpck_require__(4569));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const v3 = (0, _v.default)('v3', 0x30, _md.default);
+var _default = v3;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 5998:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = _default;
+exports.URL = exports.DNS = void 0;
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+var _parse = _interopRequireDefault(__nccwpck_require__(2746));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function stringToBytes(str) {
+  str = unescape(encodeURIComponent(str)); // UTF8 escape
+
+  const bytes = [];
+
+  for (let i = 0; i < str.length; ++i) {
+    bytes.push(str.charCodeAt(i));
+  }
+
+  return bytes;
+}
+
+const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+exports.DNS = DNS;
+const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+exports.URL = URL;
+
+function _default(name, version, hashfunc) {
+  function generateUUID(value, namespace, buf, offset) {
+    if (typeof value === 'string') {
+      value = stringToBytes(value);
+    }
+
+    if (typeof namespace === 'string') {
+      namespace = (0, _parse.default)(namespace);
+    }
+
+    if (namespace.length !== 16) {
+      throw TypeError('Namespace must be array-like (16 iterable integer values, 0-255)');
+    } // Compute hash of namespace and value, Per 4.3
+    // Future: Use spread syntax when supported on all platforms, e.g. `bytes =
+    // hashfunc([...namespace, ... value])`
+
+
+    let bytes = new Uint8Array(16 + value.length);
+    bytes.set(namespace);
+    bytes.set(value, namespace.length);
+    bytes = hashfunc(bytes);
+    bytes[6] = bytes[6] & 0x0f | version;
+    bytes[8] = bytes[8] & 0x3f | 0x80;
+
+    if (buf) {
+      offset = offset || 0;
+
+      for (let i = 0; i < 16; ++i) {
+        buf[offset + i] = bytes[i];
+      }
+
+      return buf;
+    }
+
+    return (0, _stringify.default)(bytes);
+  } // Function#name is not settable on some platforms (#270)
+
+
+  try {
+    generateUUID.name = name; // eslint-disable-next-line no-empty
+  } catch (err) {} // For CommonJS default export support
+
+
+  generateUUID.DNS = DNS;
+  generateUUID.URL = URL;
+  return generateUUID;
+}
+
+/***/ }),
+
+/***/ 5122:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(8950));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function v4(options, buf, offset) {
+  options = options || {};
+
+  const rnds = options.random || (options.rng || _rng.default)(); // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+
+
+  rnds[6] = rnds[6] & 0x0f | 0x40;
+  rnds[8] = rnds[8] & 0x3f | 0x80; // Copy bytes to buffer, if provided
+
+  if (buf) {
+    offset = offset || 0;
+
+    for (let i = 0; i < 16; ++i) {
+      buf[offset + i] = rnds[i];
+    }
+
+    return buf;
+  }
+
+  return (0, _stringify.default)(rnds);
+}
+
+var _default = v4;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 9120:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _v = _interopRequireDefault(__nccwpck_require__(5998));
+
+var _sha = _interopRequireDefault(__nccwpck_require__(5274));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const v5 = (0, _v.default)('v5', 0x50, _sha.default);
+var _default = v5;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 6900:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _regex = _interopRequireDefault(__nccwpck_require__(814));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function validate(uuid) {
+  return typeof uuid === 'string' && _regex.default.test(uuid);
+}
+
+var _default = validate;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 1595:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(6900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function version(uuid) {
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  return parseInt(uuid.substr(14, 1), 16);
+}
+
+var _default = version;
+exports["default"] = _default;
+
+/***/ }),
+
 /***/ 4886:
 /***/ ((module) => {
 
@@ -10333,41 +10987,79 @@ const utils_1 = __nccwpck_require__(691);
 (0, utils_1.runAction)(() => __awaiter(void 0, void 0, void 0, function* () {
     var _a;
     const token = core.getInput('token', { required: true });
-    const domain = core.getInput('domain', { required: true });
-    const permalink = core.getInput('permalink');
+    const linksJSON = core.getInput('links', { required: true });
     const appName = core.getInput('app_name', { required: true });
+    const asLabels = core.getInput('as_labels') === 'true';
     const repo = github.context.repo;
     const prNumber = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.number;
-    yield postPreviewUrls({ domain, permalink, token, prNumber, repo, appName });
+    yield postPreviewUrls({ linksJSON, token, prNumber, repo, appName, asLabels });
 }));
-function postPreviewUrls({ token, domain, repo, prNumber, permalink, appName }) {
+function postPreviewUrls({ token, linksJSON, repo, prNumber, appName, asLabels }) {
     var _a, _b, _c, _d;
     return __awaiter(this, void 0, void 0, function* () {
         if (!prNumber) {
             throw new Error('Called outside of a PR context.');
         }
         const octokit = github.getOctokit(token);
-        const latestPR = yield octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', Object.assign(Object.assign({}, repo), { pull_number: prNumber }));
-        const branchName = (0, utils_1.getSanitizedBranchName)(latestPR.data.head.ref);
-        const prBody = latestPR.data.body;
-        const markerStart = `<!--${domain}-preview-urls-do-not-change-below-->`;
-        const markerEnd = `<!--${domain}-preview-urls-do-not-change-above-->`;
-        const isFreshPR = !(prBody === null || prBody === void 0 ? void 0 : prBody.includes(markerStart));
-        const isDeploying = !permalink && isFreshPR;
-        const prDescriptionAbove = (_b = (_a = prBody === null || prBody === void 0 ? void 0 : prBody.split(markerStart)[0]) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : '';
-        const prDescriptionBelow = (_d = (_c = prBody === null || prBody === void 0 ? void 0 : prBody.split(markerEnd).pop()) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : '';
-        const body = `${prDescriptionAbove}
-${markerStart}
----
-**${appName} preview links**
-_Latest_: https://${branchName}.${domain}${isDeploying ? ' (Deploying... 🚧)' : ''}
-_Current permalink_: ${permalink !== null && permalink !== void 0 ? permalink : '(Deploying... 🚧)'}
-${markerEnd}
-${isFreshPR ? '' : prDescriptionBelow}`.trimEnd();
+        const links = parseLinks(linksJSON);
+        const prDescription = yield getPRDescription(octokit, prNumber, repo);
+        const appLabel = appName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+        const markerStart = `<!--${appLabel}-preview-urls-do-not-change-below-->`;
+        const markerEnd = `<!--${appLabel}-preview-urls-do-not-change-above-->`;
+        const isFreshPR = !(prDescription === null || prDescription === void 0 ? void 0 : prDescription.includes(markerStart));
+        const prDescriptionAbove = (_b = (_a = prDescription === null || prDescription === void 0 ? void 0 : prDescription.split(markerStart)[0]) === null || _a === void 0 ? void 0 : _a.trim()) !== null && _b !== void 0 ? _b : '';
+        const prDescriptionBelow = (_d = (_c = prDescription === null || prDescription === void 0 ? void 0 : prDescription.split(markerEnd).pop()) === null || _c === void 0 ? void 0 : _c.trim()) !== null && _d !== void 0 ? _d : '';
+        const linksMessages = links
+            .map((link) => {
+            if (asLabels) {
+                return `[${link.name}](${link.url})`;
+            }
+            return `_${link.name}_: ${link.url}`;
+        })
+            .join(asLabels ? ', ' : '\n');
+        const heading = `**${appName} preview links**`;
+        const body = [
+            prDescriptionAbove,
+            markerStart,
+            '---',
+            heading,
+            linksMessages,
+            markerEnd,
+            isFreshPR ? '' : prDescriptionBelow
+        ]
+            .join('\n')
+            .trimEnd();
         yield octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', Object.assign(Object.assign({}, repo), { pull_number: prNumber, body }));
     });
 }
 exports.postPreviewUrls = postPreviewUrls;
+function parseLinks(linksJSON) {
+    let links;
+    try {
+        links = JSON.parse(linksJSON);
+    }
+    catch (error) {
+        throw new Error('Links must be valid JSON');
+    }
+    if (!Array.isArray(links)) {
+        throw new Error('Links must be an array of links');
+    }
+    for (const link of links) {
+        if (!link.name ||
+            !link.url ||
+            typeof link.name !== 'string' ||
+            typeof link.url !== 'string') {
+            throw new Error('Each link must be an object with name and url string props');
+        }
+    }
+    return links;
+}
+function getPRDescription(octokit, prNumber, repo) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const pullRequest = yield octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', Object.assign(Object.assign({}, repo), { pull_number: prNumber }));
+        return pullRequest.data.body;
+    });
+}
 
 
 /***/ }),
@@ -10410,7 +11102,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.isHeadAncestor = exports.getSanitizedBranchName = exports.runAction = exports.removeFileFromS3 = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.execIsSuccessful = exports.execReadOutput = void 0;
+exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.isHeadAncestor = exports.runAction = exports.removeFileFromS3 = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.execIsSuccessful = exports.execReadOutput = void 0;
 const exec_1 = __nccwpck_require__(1514);
 const core = __importStar(__nccwpck_require__(2186));
 /**
@@ -10524,22 +11216,6 @@ function runAction(action) {
 }
 exports.runAction = runAction;
 /**
- * Retrieve and convert the current git branch name to a string that is safe
- * for use as a S3 file key and a URL segment
- * @returns branchName
- */
-function getSanitizedBranchName(ref) {
-    var _a;
-    const branchName = (_a = ref
-        .split('refs/heads/')
-        .pop()) === null || _a === void 0 ? void 0 : _a.replace(/[^\w]/gi, '-').replace(/-{2,}/gi, '-').toLowerCase().slice(0, 60).trim();
-    if (!branchName) {
-        throw new Error('Invalid context, could not calculate sanitized branch name');
-    }
-    return branchName;
-}
-exports.getSanitizedBranchName = getSanitizedBranchName;
-/**
  * Validate if the passed git commit hash is present on the current branch
  * @param commitHash - commit hash to validate
  * @returns isHeadAncestor
@@ -10598,6 +11274,14 @@ module.exports = require("assert");
 
 "use strict";
 module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 6113:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("crypto");
 
 /***/ }),
 

--- a/actions/post-preview-urls/main.test.ts
+++ b/actions/post-preview-urls/main.test.ts
@@ -1,6 +1,5 @@
 import {stripIndent as strip} from 'common-tags'
 import {postPreviewUrls} from './main'
-import * as utils from '../utils'
 import * as github from '@actions/github'
 
 jest.mock('../utils')
@@ -8,37 +7,25 @@ jest.mock('@actions/core')
 jest.mock('@actions/github')
 
 // just making sure the mock methods are correctly typed
-const mockedUtils = utils as jest.Mocked<typeof utils>
-const mockedGithub = github as jest.Mocked<typeof github>
-
-// reset the counter on mock fn calls after every test
-beforeEach(() => jest.clearAllMocks())
-
-// use the actual method for sanitizing branch names
-const originalUtils = jest.requireActual('../utils')
-mockedUtils.getSanitizedBranchName.mockImplementation(originalUtils.getSanitizedBranchName)
+const mockedGithub = jest.mocked(github)
 
 describe(`Post Preview URLs action`, () => {
     test(
         strip`
         When the PR does not yet have the preview links for the app
-        And there is no tree hash provided
-        It updates the PR description
-        And latest link is posted, marked as deploying
-        And the permalink is not posted and it's marked as deploying
+        It adds the links passed to the PR description
         `,
         async () => {
             const token = '1234'
             const mockRequest = jest.fn().mockResolvedValueOnce({
-                data: {
-                    body: 'Hello World!\n Some indent',
-                    head: {ref: 'refs/heads/lol/my-feature-branch-30%-better'}
-                }
+                data: {body: 'Hello World!\n Some indent'}
             })
             mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
 
             await postPreviewUrls({
-                domain: 'app.example.com',
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature.app.example.com'}
+                ]),
                 token,
                 repo: {owner: 'my-org', repo: 'my-repo'},
                 prNumber: 1,
@@ -46,31 +33,80 @@ describe(`Post Preview URLs action`, () => {
             })
 
             expect(mockedGithub.getOctokit).toBeCalledWith(token)
-            expect(mockRequest).toBeCalledWith('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-                body: strip`
+            expect(mockRequest).toHaveBeenLastCalledWith(
+                'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                    body: strip`
                     Hello World!
                      Some indent
-                    <!--app.example.com-preview-urls-do-not-change-below-->
+                    <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
-                    _Latest_: https://lol-my-feature-branch-30-better.app.example.com (Deploying... 🚧)
-                    _Current permalink_: (Deploying... 🚧)
-                    <!--app.example.com-preview-urls-do-not-change-above-->
+                    _Latest_: https://feature.app.example.com
+                    <!--app-preview-urls-do-not-change-above-->
                 `,
-                owner: 'my-org',
-                pull_number: 1,
-                repo: 'my-repo'
+                    owner: 'my-org',
+                    pull_number: 1,
+                    repo: 'my-repo'
+                }
+            )
+        }
+    )
+
+    test(
+        strip`
+        When the PR does not yet have the preview links for the app
+        And the links are requested as labels
+        It adds the links passed to the PR description
+        And renders the links as labels, hiding the URL
+        `,
+        async () => {
+            const token = '1234'
+            const mockRequest = jest.fn().mockResolvedValueOnce({
+                data: {body: 'Hello World!\n Some indent'}
             })
+            mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
+
+            await postPreviewUrls({
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature.app.example.com'},
+                    {
+                        name: 'Current Permalink',
+                        url: 'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com'
+                    }
+                ]),
+                token,
+                repo: {owner: 'my-org', repo: 'my-repo'},
+                prNumber: 1,
+                appName: '🤖 App',
+                asLabels: true
+            })
+
+            expect(mockedGithub.getOctokit).toBeCalledWith(token)
+            expect(mockRequest).toHaveBeenLastCalledWith(
+                'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                    body: strip`
+                    Hello World!
+                     Some indent
+                    <!--app-preview-urls-do-not-change-below-->
+                    ---
+                    **🤖 App preview links**
+                    [Latest](https://feature.app.example.com), [Current Permalink](https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com)
+                    <!--app-preview-urls-do-not-change-above-->
+                `,
+                    owner: 'my-org',
+                    pull_number: 1,
+                    repo: 'my-repo'
+                }
+            )
         }
     )
 
     test(
         strip`
         When the PR already has the preview links for the app
-        And there is no tree hash provided
-        It updates the PR description
-        And latest link is posted
-        And the permalink is not posted and it's marked as deploying
+        It updates the links in the PR description
         `,
         async () => {
             const token = '1234'
@@ -78,20 +114,21 @@ describe(`Post Preview URLs action`, () => {
                 data: {
                     body: strip`
                         Hello World!
-                        <!--app.example.com-preview-urls-do-not-change-below-->
+                         Some indent
+                        <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
-                        _Latest_: https://lol-my-feature-branch-30-better.app.example.com (Deploying... 🚧)
-                        _Current permalink_: (Deploying... 🚧)
-                        <!--app.example.com-preview-urls-do-not-change-above-->
-                    `,
-                    head: {ref: 'refs/heads/lol/my-feature-branch-30%-better'}
+                        _Latest_: https://feature.app.example.com
+                        <!--app-preview-urls-do-not-change-above-->
+                    `
                 }
             })
             mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
 
             await postPreviewUrls({
-                domain: 'app.example.com',
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature-2.app.example.com'}
+                ]),
                 token,
                 repo: {owner: 'my-org', repo: 'my-repo'},
                 prNumber: 1,
@@ -99,75 +136,79 @@ describe(`Post Preview URLs action`, () => {
             })
 
             expect(mockedGithub.getOctokit).toBeCalledWith(token)
-            expect(mockRequest).toBeCalledWith('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-                body: strip`
+            expect(mockRequest).toHaveBeenLastCalledWith(
+                'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                    body: strip`
                     Hello World!
-                    <!--app.example.com-preview-urls-do-not-change-below-->
+                     Some indent
+                    <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
-                    _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                    _Current permalink_: (Deploying... 🚧)
-                    <!--app.example.com-preview-urls-do-not-change-above-->
+                    _Latest_: https://feature-2.app.example.com
+                    <!--app-preview-urls-do-not-change-above-->
                 `,
-                owner: 'my-org',
-                pull_number: 1,
-                repo: 'my-repo'
-            })
+                    owner: 'my-org',
+                    pull_number: 1,
+                    repo: 'my-repo'
+                }
+            )
         }
     )
 
     test(
         strip`
-        When the PR already has the preview links for the app
-        And there is a tree hash provided
-        It updates the PR description
-        And latest link is posted
-        And the permalink is posted
+        When there are multiple links passed
+        It posts all links in the PR description
         `,
         async () => {
             const token = '1234'
-            const permalink =
-                'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com'
             const mockRequest = jest.fn().mockResolvedValueOnce({
                 data: {
                     body: strip`
                         Hello World!
-                        <!--app.example.com-preview-urls-do-not-change-below-->
+                        <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
-                        _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                        _Current permalink_: (Deploying... 🚧)
-                        <!--app.example.com-preview-urls-do-not-change-above-->
-                    `,
-                    head: {ref: 'refs/heads/lol/my-feature-branch-30%-better'}
+                        _Latest_: https://feature.app.example.com
+                        <!--app-preview-urls-do-not-change-above-->
+                    `
                 }
             })
             mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
 
             await postPreviewUrls({
-                domain: 'app.example.com',
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature.app.example.com'},
+                    {
+                        name: 'Current Permalink',
+                        url: 'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com'
+                    }
+                ]),
                 token,
-                permalink,
                 repo: {owner: 'my-org', repo: 'my-repo'},
                 prNumber: 1,
                 appName: '🤖 App'
             })
 
             expect(mockedGithub.getOctokit).toBeCalledWith(token)
-            expect(mockRequest).toBeCalledWith('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-                body: strip`
+            expect(mockRequest).toHaveBeenLastCalledWith(
+                'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                    body: strip`
                     Hello World!
-                    <!--app.example.com-preview-urls-do-not-change-below-->
+                    <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
-                    _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                    _Current permalink_: ${permalink}
-                    <!--app.example.com-preview-urls-do-not-change-above-->
+                    _Latest_: https://feature.app.example.com
+                    _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
+                    <!--app-preview-urls-do-not-change-above-->
                 `,
-                owner: 'my-org',
-                pull_number: 1,
-                repo: 'my-repo'
-            })
+                    owner: 'my-org',
+                    pull_number: 1,
+                    repo: 'my-repo'
+                }
+            )
         }
     )
 
@@ -179,18 +220,16 @@ describe(`Post Preview URLs action`, () => {
         `,
         async () => {
             const token = '1234'
-            const permalink =
-                'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.storybook.example.com'
             const mockRequest = jest.fn().mockResolvedValueOnce({
                 data: {
                     body: strip`
                         Hello World!
-                        <!--app.example.com-preview-urls-do-not-change-below-->
+                        <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
-                        _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                        _Current permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
-                        <!--app.example.com-preview-urls-do-not-change-above-->
+                        _Latest_: https://feature.app.example.com
+                        _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
+                        <!--app-preview-urls-do-not-change-above-->
                     `,
                     head: {ref: 'refs/heads/lol/my-feature-branch-30%-better'}
                 }
@@ -198,35 +237,43 @@ describe(`Post Preview URLs action`, () => {
             mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
 
             await postPreviewUrls({
-                domain: 'storybook.example.com',
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature.storybook.example.com'},
+                    {
+                        name: 'Current Permalink',
+                        url: 'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.storybook.example.com'
+                    }
+                ]),
                 token,
-                permalink,
                 repo: {owner: 'my-org', repo: 'my-repo'},
                 prNumber: 1,
                 appName: '🤖 Storybook'
             })
 
             expect(mockedGithub.getOctokit).toBeCalledWith(token)
-            expect(mockRequest).toBeCalledWith('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-                body: strip`
+            expect(mockRequest).toHaveBeenLastCalledWith(
+                'PATCH /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                    body: strip`
                         Hello World!
-                        <!--app.example.com-preview-urls-do-not-change-below-->
+                        <!--app-preview-urls-do-not-change-below-->
                         ---
                         **🤖 App preview links**
-                        _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                        _Current permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
-                        <!--app.example.com-preview-urls-do-not-change-above-->
-                        <!--storybook.example.com-preview-urls-do-not-change-below-->
+                        _Latest_: https://feature.app.example.com
+                        _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
+                        <!--app-preview-urls-do-not-change-above-->
+                        <!--storybook-preview-urls-do-not-change-below-->
                         ---
                         **🤖 Storybook preview links**
-                        _Latest_: https://lol-my-feature-branch-30-better.storybook.example.com
-                        _Current permalink_: ${permalink}
-                        <!--storybook.example.com-preview-urls-do-not-change-above-->
+                        _Latest_: https://feature.storybook.example.com
+                        _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.storybook.example.com
+                        <!--storybook-preview-urls-do-not-change-above-->
                     `,
-                owner: 'my-org',
-                pull_number: 1,
-                repo: 'my-repo'
-            })
+                    owner: 'my-org',
+                    pull_number: 1,
+                    repo: 'my-repo'
+                }
+            )
         }
     )
 
@@ -239,24 +286,22 @@ describe(`Post Preview URLs action`, () => {
         `,
         async () => {
             const token = '1234'
-            const permalink =
-                'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.storybook.example.com'
             const mockRequest = jest.fn().mockResolvedValueOnce({
                 data: {
                     body: strip`
                     Hello World!
-                    <!--storybook.example.com-preview-urls-do-not-change-below-->
+                    <!--storybook-preview-urls-do-not-change-below-->
                     ---
                     **🤖 Storybook preview links**
-                    _Latest_: https://lol-my-feature-branch-30-better.storybook.example.com
-                    _Current permalink_:https://preview-0ce99f79fa377f39248fa0633b21bdb130728674.storybook.example.com
-                    <!--storybook.example.com-preview-urls-do-not-change-above-->
-                    <!--app.example.com-preview-urls-do-not-change-below-->
+                    _Latest_: https://feature.storybook.example.com
+                    _Current Permalink_: https://preview-0ce99f79fa377f39248fa0633b21bdb130728674.storybook.example.com
+                    <!--storybook-preview-urls-do-not-change-above-->
+                    <!--app-preview-urls-do-not-change-below-->
                     ---
                     **🤖 App preview links**
-                    _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                    _Current permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
-                    <!--app.example.com-preview-urls-do-not-change-above-->
+                    _Latest_: https://feature.app.example.com
+                    _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
+                    <!--app-preview-urls-do-not-change-above-->
                 `,
                     head: {ref: 'refs/heads/lol/my-feature-branch-30%-better'}
                 }
@@ -264,9 +309,14 @@ describe(`Post Preview URLs action`, () => {
             mockedGithub.getOctokit.mockReturnValue({request: mockRequest} as any)
 
             await postPreviewUrls({
-                domain: 'storybook.example.com',
+                linksJSON: JSON.stringify([
+                    {name: 'Latest', url: 'https://feature.storybook.example.com'},
+                    {
+                        name: 'Current Permalink',
+                        url: 'https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.storybook.example.com'
+                    }
+                ]),
                 token,
-                permalink,
                 repo: {owner: 'my-org', repo: 'my-repo'},
                 prNumber: 1,
                 appName: '📚 Storybook'
@@ -276,18 +326,18 @@ describe(`Post Preview URLs action`, () => {
             expect(mockRequest).toBeCalledWith('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
                 body: strip`
                 Hello World!
-                <!--storybook.example.com-preview-urls-do-not-change-below-->
+                <!--storybook-preview-urls-do-not-change-below-->
                 ---
                 **📚 Storybook preview links**
-                _Latest_: https://lol-my-feature-branch-30-better.storybook.example.com
-                _Current permalink_: ${permalink}
-                <!--storybook.example.com-preview-urls-do-not-change-above-->
-                <!--app.example.com-preview-urls-do-not-change-below-->
+                _Latest_: https://feature.storybook.example.com
+                _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.storybook.example.com
+                <!--storybook-preview-urls-do-not-change-above-->
+                <!--app-preview-urls-do-not-change-below-->
                 ---
                 **🤖 App preview links**
-                _Latest_: https://lol-my-feature-branch-30-better.app.example.com
-                _Current permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
-                <!--app.example.com-preview-urls-do-not-change-above-->
+                _Latest_: https://feature.app.example.com
+                _Current Permalink_: https://preview-c819fdae556e892d5d25de24db6bd6997e673ec6.app.example.com
+                <!--app-preview-urls-do-not-change-above-->
             `,
                 owner: 'my-org',
                 pull_number: 1,

--- a/actions/post-preview-urls/main.ts
+++ b/actions/post-preview-urls/main.ts
@@ -5,68 +5,117 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 
-import {getSanitizedBranchName, runAction} from '../utils'
+import {runAction} from '../utils'
 
 runAction(async () => {
     const token = core.getInput('token', {required: true})
-    const domain = core.getInput('domain', {required: true})
-    const permalink = core.getInput('permalink')
+    const linksJSON = core.getInput('links', {required: true})
     const appName = core.getInput('app_name', {required: true})
+    const asLabels = core.getInput('as_labels') === 'true'
     const repo = github.context.repo
     const prNumber = github.context.payload.pull_request?.number
 
-    await postPreviewUrls({domain, permalink, token, prNumber, repo, appName})
+    await postPreviewUrls({linksJSON, token, prNumber, repo, appName, asLabels})
 })
 
 interface PostPreviewUrlsActionArgs {
     token: string
-    domain: string
     prNumber?: number
     repo: typeof github.context.repo
-    permalink?: string
     appName: string
+    linksJSON: string
+    asLabels?: boolean
 }
 
 export async function postPreviewUrls({
     token,
-    domain,
+    linksJSON,
     repo,
     prNumber,
-    permalink,
-    appName
+    appName,
+    asLabels
 }: PostPreviewUrlsActionArgs) {
     if (!prNumber) {
         throw new Error('Called outside of a PR context.')
     }
-
     const octokit = github.getOctokit(token)
+    const links = parseLinks(linksJSON)
+    const prDescription = await getPRDescription(octokit, prNumber, repo)
 
-    const latestPR = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
-        ...repo,
-        pull_number: prNumber
-    })
-    const branchName = getSanitizedBranchName(latestPR.data.head.ref)
-    const prBody = latestPR.data.body
+    const appLabel = appName.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
+    const markerStart = `<!--${appLabel}-preview-urls-do-not-change-below-->`
+    const markerEnd = `<!--${appLabel}-preview-urls-do-not-change-above-->`
 
-    const markerStart = `<!--${domain}-preview-urls-do-not-change-below-->`
-    const markerEnd = `<!--${domain}-preview-urls-do-not-change-above-->`
-    const isFreshPR = !prBody?.includes(markerStart)
-    const isDeploying = !permalink && isFreshPR
-    const prDescriptionAbove = prBody?.split(markerStart)[0]?.trim() ?? ''
-    const prDescriptionBelow = prBody?.split(markerEnd).pop()?.trim() ?? ''
+    const isFreshPR = !prDescription?.includes(markerStart)
 
-    const body = `${prDescriptionAbove}
-${markerStart}
----
-**${appName} preview links**
-_Latest_: https://${branchName}.${domain}${isDeploying ? ' (Deploying... 🚧)' : ''}
-_Current permalink_: ${permalink ?? '(Deploying... 🚧)'}
-${markerEnd}
-${isFreshPR ? '' : prDescriptionBelow}`.trimEnd()
+    const prDescriptionAbove = prDescription?.split(markerStart)[0]?.trim() ?? ''
+    const prDescriptionBelow = prDescription?.split(markerEnd).pop()?.trim() ?? ''
+
+    const linksMessages = links
+        .map((link) => {
+            if (asLabels) {
+                return `[${link.name}](${link.url})`
+            }
+            return `_${link.name}_: ${link.url}`
+        })
+        .join(asLabels ? ', ' : '\n')
+    const heading = `**${appName} preview links**`
+
+    const body = [
+        prDescriptionAbove,
+        markerStart,
+        '---',
+        heading,
+        linksMessages,
+        markerEnd,
+        isFreshPR ? '' : prDescriptionBelow
+    ]
+        .join('\n')
+        .trimEnd()
 
     await octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
         ...repo,
         pull_number: prNumber,
         body
     })
+}
+
+function parseLinks(linksJSON: string) {
+    let links: Array<{url: string; name: string}>
+
+    try {
+        links = JSON.parse(linksJSON)
+    } catch (error) {
+        throw new Error('Links must be valid JSON')
+    }
+
+    if (!Array.isArray(links)) {
+        throw new Error('Links must be an array of links')
+    }
+
+    for (const link of links) {
+        if (
+            !link.name ||
+            !link.url ||
+            typeof link.name !== 'string' ||
+            typeof link.url !== 'string'
+        ) {
+            throw new Error('Each link must be an object with name and url string props')
+        }
+    }
+
+    return links
+}
+
+async function getPRDescription(
+    octokit: ReturnType<typeof github.getOctokit>,
+    prNumber: number,
+    repo: typeof github.context.repo
+) {
+    const pullRequest = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        ...repo,
+        pull_number: prNumber
+    })
+
+    return pullRequest.data.body
 }

--- a/actions/translation-cursor-deploy/dist/main/index.js
+++ b/actions/translation-cursor-deploy/dist/main/index.js
@@ -140,6 +140,7 @@ const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(278);
 const os = __importStar(__nccwpck_require__(37));
 const path = __importStar(__nccwpck_require__(17));
+const uuid_1 = __nccwpck_require__(840);
 const oidc_utils_1 = __nccwpck_require__(41);
 /**
  * The code to exit an action
@@ -169,7 +170,14 @@ function exportVariable(name, val) {
     process.env[name] = convertedVal;
     const filePath = process.env['GITHUB_ENV'] || '';
     if (filePath) {
-        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+        // These should realistically never happen, but just in case someone finds a way to exploit uuid generation let's not allow keys or values that contain the delimiter.
+        if (name.includes(delimiter)) {
+            throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+        }
+        if (convertedVal.includes(delimiter)) {
+            throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+        }
         const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
         file_command_1.issueCommand('ENV', commandValue);
     }
@@ -3286,6 +3294,652 @@ exports.debug = debug; // for test
 
 /***/ }),
 
+/***/ 840:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+Object.defineProperty(exports, "v1", ({
+  enumerable: true,
+  get: function () {
+    return _v.default;
+  }
+}));
+Object.defineProperty(exports, "v3", ({
+  enumerable: true,
+  get: function () {
+    return _v2.default;
+  }
+}));
+Object.defineProperty(exports, "v4", ({
+  enumerable: true,
+  get: function () {
+    return _v3.default;
+  }
+}));
+Object.defineProperty(exports, "v5", ({
+  enumerable: true,
+  get: function () {
+    return _v4.default;
+  }
+}));
+Object.defineProperty(exports, "NIL", ({
+  enumerable: true,
+  get: function () {
+    return _nil.default;
+  }
+}));
+Object.defineProperty(exports, "version", ({
+  enumerable: true,
+  get: function () {
+    return _version.default;
+  }
+}));
+Object.defineProperty(exports, "validate", ({
+  enumerable: true,
+  get: function () {
+    return _validate.default;
+  }
+}));
+Object.defineProperty(exports, "stringify", ({
+  enumerable: true,
+  get: function () {
+    return _stringify.default;
+  }
+}));
+Object.defineProperty(exports, "parse", ({
+  enumerable: true,
+  get: function () {
+    return _parse.default;
+  }
+}));
+
+var _v = _interopRequireDefault(__nccwpck_require__(628));
+
+var _v2 = _interopRequireDefault(__nccwpck_require__(409));
+
+var _v3 = _interopRequireDefault(__nccwpck_require__(122));
+
+var _v4 = _interopRequireDefault(__nccwpck_require__(120));
+
+var _nil = _interopRequireDefault(__nccwpck_require__(332));
+
+var _version = _interopRequireDefault(__nccwpck_require__(595));
+
+var _validate = _interopRequireDefault(__nccwpck_require__(900));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(950));
+
+var _parse = _interopRequireDefault(__nccwpck_require__(746));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/***/ }),
+
+/***/ 569:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function md5(bytes) {
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
+  }
+
+  return _crypto.default.createHash('md5').update(bytes).digest();
+}
+
+var _default = md5;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 332:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+var _default = '00000000-0000-0000-0000-000000000000';
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 746:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function parse(uuid) {
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  let v;
+  const arr = new Uint8Array(16); // Parse ########-....-....-....-............
+
+  arr[0] = (v = parseInt(uuid.slice(0, 8), 16)) >>> 24;
+  arr[1] = v >>> 16 & 0xff;
+  arr[2] = v >>> 8 & 0xff;
+  arr[3] = v & 0xff; // Parse ........-####-....-....-............
+
+  arr[4] = (v = parseInt(uuid.slice(9, 13), 16)) >>> 8;
+  arr[5] = v & 0xff; // Parse ........-....-####-....-............
+
+  arr[6] = (v = parseInt(uuid.slice(14, 18), 16)) >>> 8;
+  arr[7] = v & 0xff; // Parse ........-....-....-####-............
+
+  arr[8] = (v = parseInt(uuid.slice(19, 23), 16)) >>> 8;
+  arr[9] = v & 0xff; // Parse ........-....-....-....-############
+  // (Use "/" to avoid 32-bit truncation when bit-shifting high-order bytes)
+
+  arr[10] = (v = parseInt(uuid.slice(24, 36), 16)) / 0x10000000000 & 0xff;
+  arr[11] = v / 0x100000000 & 0xff;
+  arr[12] = v >>> 24 & 0xff;
+  arr[13] = v >>> 16 & 0xff;
+  arr[14] = v >>> 8 & 0xff;
+  arr[15] = v & 0xff;
+  return arr;
+}
+
+var _default = parse;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 814:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+var _default = /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 807:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = rng;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const rnds8Pool = new Uint8Array(256); // # of random values to pre-allocate
+
+let poolPtr = rnds8Pool.length;
+
+function rng() {
+  if (poolPtr > rnds8Pool.length - 16) {
+    _crypto.default.randomFillSync(rnds8Pool);
+
+    poolPtr = 0;
+  }
+
+  return rnds8Pool.slice(poolPtr, poolPtr += 16);
+}
+
+/***/ }),
+
+/***/ 274:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _crypto = _interopRequireDefault(__nccwpck_require__(113));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function sha1(bytes) {
+  if (Array.isArray(bytes)) {
+    bytes = Buffer.from(bytes);
+  } else if (typeof bytes === 'string') {
+    bytes = Buffer.from(bytes, 'utf8');
+  }
+
+  return _crypto.default.createHash('sha1').update(bytes).digest();
+}
+
+var _default = sha1;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 950:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Convert array of 16 byte values to UUID string format of the form:
+ * XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+ */
+const byteToHex = [];
+
+for (let i = 0; i < 256; ++i) {
+  byteToHex.push((i + 0x100).toString(16).substr(1));
+}
+
+function stringify(arr, offset = 0) {
+  // Note: Be careful editing this code!  It's been tuned for performance
+  // and works in ways you may not expect. See https://github.com/uuidjs/uuid/pull/434
+  const uuid = (byteToHex[arr[offset + 0]] + byteToHex[arr[offset + 1]] + byteToHex[arr[offset + 2]] + byteToHex[arr[offset + 3]] + '-' + byteToHex[arr[offset + 4]] + byteToHex[arr[offset + 5]] + '-' + byteToHex[arr[offset + 6]] + byteToHex[arr[offset + 7]] + '-' + byteToHex[arr[offset + 8]] + byteToHex[arr[offset + 9]] + '-' + byteToHex[arr[offset + 10]] + byteToHex[arr[offset + 11]] + byteToHex[arr[offset + 12]] + byteToHex[arr[offset + 13]] + byteToHex[arr[offset + 14]] + byteToHex[arr[offset + 15]]).toLowerCase(); // Consistency check for valid UUID.  If this throws, it's likely due to one
+  // of the following:
+  // - One or more input array values don't map to a hex octet (leading to
+  // "undefined" in the uuid)
+  // - Invalid input values for the RFC `version` or `variant` fields
+
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Stringified UUID is invalid');
+  }
+
+  return uuid;
+}
+
+var _default = stringify;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 628:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(950));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// **`v1()` - Generate time-based UUID**
+//
+// Inspired by https://github.com/LiosK/UUID.js
+// and http://docs.python.org/library/uuid.html
+let _nodeId;
+
+let _clockseq; // Previous uuid creation time
+
+
+let _lastMSecs = 0;
+let _lastNSecs = 0; // See https://github.com/uuidjs/uuid for API details
+
+function v1(options, buf, offset) {
+  let i = buf && offset || 0;
+  const b = buf || new Array(16);
+  options = options || {};
+  let node = options.node || _nodeId;
+  let clockseq = options.clockseq !== undefined ? options.clockseq : _clockseq; // node and clockseq need to be initialized to random values if they're not
+  // specified.  We do this lazily to minimize issues related to insufficient
+  // system entropy.  See #189
+
+  if (node == null || clockseq == null) {
+    const seedBytes = options.random || (options.rng || _rng.default)();
+
+    if (node == null) {
+      // Per 4.5, create and 48-bit node id, (47 random bits + multicast bit = 1)
+      node = _nodeId = [seedBytes[0] | 0x01, seedBytes[1], seedBytes[2], seedBytes[3], seedBytes[4], seedBytes[5]];
+    }
+
+    if (clockseq == null) {
+      // Per 4.2.2, randomize (14 bit) clockseq
+      clockseq = _clockseq = (seedBytes[6] << 8 | seedBytes[7]) & 0x3fff;
+    }
+  } // UUID timestamps are 100 nano-second units since the Gregorian epoch,
+  // (1582-10-15 00:00).  JSNumbers aren't precise enough for this, so
+  // time is handled internally as 'msecs' (integer milliseconds) and 'nsecs'
+  // (100-nanoseconds offset from msecs) since unix epoch, 1970-01-01 00:00.
+
+
+  let msecs = options.msecs !== undefined ? options.msecs : Date.now(); // Per 4.2.1.2, use count of uuid's generated during the current clock
+  // cycle to simulate higher resolution clock
+
+  let nsecs = options.nsecs !== undefined ? options.nsecs : _lastNSecs + 1; // Time since last uuid creation (in msecs)
+
+  const dt = msecs - _lastMSecs + (nsecs - _lastNSecs) / 10000; // Per 4.2.1.2, Bump clockseq on clock regression
+
+  if (dt < 0 && options.clockseq === undefined) {
+    clockseq = clockseq + 1 & 0x3fff;
+  } // Reset nsecs if clock regresses (new clockseq) or we've moved onto a new
+  // time interval
+
+
+  if ((dt < 0 || msecs > _lastMSecs) && options.nsecs === undefined) {
+    nsecs = 0;
+  } // Per 4.2.1.2 Throw error if too many uuids are requested
+
+
+  if (nsecs >= 10000) {
+    throw new Error("uuid.v1(): Can't create more than 10M uuids/sec");
+  }
+
+  _lastMSecs = msecs;
+  _lastNSecs = nsecs;
+  _clockseq = clockseq; // Per 4.1.4 - Convert from unix epoch to Gregorian epoch
+
+  msecs += 12219292800000; // `time_low`
+
+  const tl = ((msecs & 0xfffffff) * 10000 + nsecs) % 0x100000000;
+  b[i++] = tl >>> 24 & 0xff;
+  b[i++] = tl >>> 16 & 0xff;
+  b[i++] = tl >>> 8 & 0xff;
+  b[i++] = tl & 0xff; // `time_mid`
+
+  const tmh = msecs / 0x100000000 * 10000 & 0xfffffff;
+  b[i++] = tmh >>> 8 & 0xff;
+  b[i++] = tmh & 0xff; // `time_high_and_version`
+
+  b[i++] = tmh >>> 24 & 0xf | 0x10; // include version
+
+  b[i++] = tmh >>> 16 & 0xff; // `clock_seq_hi_and_reserved` (Per 4.2.2 - include variant)
+
+  b[i++] = clockseq >>> 8 | 0x80; // `clock_seq_low`
+
+  b[i++] = clockseq & 0xff; // `node`
+
+  for (let n = 0; n < 6; ++n) {
+    b[i + n] = node[n];
+  }
+
+  return buf || (0, _stringify.default)(b);
+}
+
+var _default = v1;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 409:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _v = _interopRequireDefault(__nccwpck_require__(998));
+
+var _md = _interopRequireDefault(__nccwpck_require__(569));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const v3 = (0, _v.default)('v3', 0x30, _md.default);
+var _default = v3;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 998:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = _default;
+exports.URL = exports.DNS = void 0;
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(950));
+
+var _parse = _interopRequireDefault(__nccwpck_require__(746));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function stringToBytes(str) {
+  str = unescape(encodeURIComponent(str)); // UTF8 escape
+
+  const bytes = [];
+
+  for (let i = 0; i < str.length; ++i) {
+    bytes.push(str.charCodeAt(i));
+  }
+
+  return bytes;
+}
+
+const DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+exports.DNS = DNS;
+const URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+exports.URL = URL;
+
+function _default(name, version, hashfunc) {
+  function generateUUID(value, namespace, buf, offset) {
+    if (typeof value === 'string') {
+      value = stringToBytes(value);
+    }
+
+    if (typeof namespace === 'string') {
+      namespace = (0, _parse.default)(namespace);
+    }
+
+    if (namespace.length !== 16) {
+      throw TypeError('Namespace must be array-like (16 iterable integer values, 0-255)');
+    } // Compute hash of namespace and value, Per 4.3
+    // Future: Use spread syntax when supported on all platforms, e.g. `bytes =
+    // hashfunc([...namespace, ... value])`
+
+
+    let bytes = new Uint8Array(16 + value.length);
+    bytes.set(namespace);
+    bytes.set(value, namespace.length);
+    bytes = hashfunc(bytes);
+    bytes[6] = bytes[6] & 0x0f | version;
+    bytes[8] = bytes[8] & 0x3f | 0x80;
+
+    if (buf) {
+      offset = offset || 0;
+
+      for (let i = 0; i < 16; ++i) {
+        buf[offset + i] = bytes[i];
+      }
+
+      return buf;
+    }
+
+    return (0, _stringify.default)(bytes);
+  } // Function#name is not settable on some platforms (#270)
+
+
+  try {
+    generateUUID.name = name; // eslint-disable-next-line no-empty
+  } catch (err) {} // For CommonJS default export support
+
+
+  generateUUID.DNS = DNS;
+  generateUUID.URL = URL;
+  return generateUUID;
+}
+
+/***/ }),
+
+/***/ 122:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _rng = _interopRequireDefault(__nccwpck_require__(807));
+
+var _stringify = _interopRequireDefault(__nccwpck_require__(950));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function v4(options, buf, offset) {
+  options = options || {};
+
+  const rnds = options.random || (options.rng || _rng.default)(); // Per 4.4, set bits for version and `clock_seq_hi_and_reserved`
+
+
+  rnds[6] = rnds[6] & 0x0f | 0x40;
+  rnds[8] = rnds[8] & 0x3f | 0x80; // Copy bytes to buffer, if provided
+
+  if (buf) {
+    offset = offset || 0;
+
+    for (let i = 0; i < 16; ++i) {
+      buf[offset + i] = rnds[i];
+    }
+
+    return buf;
+  }
+
+  return (0, _stringify.default)(rnds);
+}
+
+var _default = v4;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 120:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _v = _interopRequireDefault(__nccwpck_require__(998));
+
+var _sha = _interopRequireDefault(__nccwpck_require__(274));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const v5 = (0, _v.default)('v5', 0x50, _sha.default);
+var _default = v5;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 900:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _regex = _interopRequireDefault(__nccwpck_require__(814));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function validate(uuid) {
+  return typeof uuid === 'string' && _regex.default.test(uuid);
+}
+
+var _default = validate;
+exports["default"] = _default;
+
+/***/ }),
+
+/***/ 595:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({
+  value: true
+}));
+exports["default"] = void 0;
+
+var _validate = _interopRequireDefault(__nccwpck_require__(900));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function version(uuid) {
+  if (!(0, _validate.default)(uuid)) {
+    throw TypeError('Invalid UUID');
+  }
+
+  return parseInt(uuid.substr(14, 1), 16);
+}
+
+var _default = version;
+exports["default"] = _default;
+
+/***/ }),
+
 /***/ 410:
 /***/ ((__unused_webpack_module, exports) => {
 
@@ -3453,7 +4107,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.isHeadAncestor = exports.getSanitizedBranchName = exports.runAction = exports.removeFileFromS3 = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.execIsSuccessful = exports.execReadOutput = void 0;
+exports.getCurrentRepoTreeHash = exports.getTreeHashForCommitHash = exports.isHeadAncestor = exports.runAction = exports.removeFileFromS3 = exports.copyFileToS3 = exports.writeLineToFile = exports.fileExistsInS3 = exports.execIsSuccessful = exports.execReadOutput = void 0;
 const exec_1 = __nccwpck_require__(514);
 const core = __importStar(__nccwpck_require__(186));
 /**
@@ -3567,22 +4221,6 @@ function runAction(action) {
 }
 exports.runAction = runAction;
 /**
- * Retrieve and convert the current git branch name to a string that is safe
- * for use as a S3 file key and a URL segment
- * @returns branchName
- */
-function getSanitizedBranchName(ref) {
-    var _a;
-    const branchName = (_a = ref
-        .split('refs/heads/')
-        .pop()) === null || _a === void 0 ? void 0 : _a.replace(/[^\w]/gi, '-').replace(/-{2,}/gi, '-').toLowerCase().slice(0, 60).trim();
-    if (!branchName) {
-        throw new Error('Invalid context, could not calculate sanitized branch name');
-    }
-    return branchName;
-}
-exports.getSanitizedBranchName = getSanitizedBranchName;
-/**
  * Validate if the passed git commit hash is present on the current branch
  * @param commitHash - commit hash to validate
  * @returns isHeadAncestor
@@ -3633,6 +4271,14 @@ module.exports = require("assert");
 
 "use strict";
 module.exports = require("child_process");
+
+/***/ }),
+
+/***/ 113:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("crypto");
 
 /***/ }),
 

--- a/actions/translation-cursor-deploy/main.test.ts
+++ b/actions/translation-cursor-deploy/main.test.ts
@@ -8,10 +8,7 @@ jest.mock('@actions/core')
 jest.mock('@actions/github')
 
 // just making sure the mock methods are correctly typed
-const mockedUtils = utils as jest.Mocked<typeof utils>
-
-// reset the counter on mock fn calls after every test
-beforeEach(() => jest.clearAllMocks())
+const mockedUtils = jest.mocked(utils)
 
 describe(`Translation Cursor Deploy Action`, () => {
     test(

--- a/actions/utils.test.ts
+++ b/actions/utils.test.ts
@@ -1,6 +1,5 @@
 import * as utils from './utils'
 import {exec} from '@actions/exec'
-import * as core from '@actions/core'
 
 jest.mock('@actions/core')
 jest.mock('@actions/exec')
@@ -91,34 +90,6 @@ describe(`Actions Utils`, () => {
             mockedExec.mockResolvedValue(0)
             await utils.removeFileFromS3({key: 'my/key', bucket: 'my-bucket'})
             expect(mockedExec).toHaveBeenCalledWith('aws s3 rm', ['s3://my-bucket/my/key'])
-        })
-    })
-
-    describe('Branch Sanitize - getSanitizedBranchName', () => {
-        test(`sanitizes a full git ref into a DNS-ready string`, async () => {
-            const output = utils.getSanitizedBranchName('refs/heads/hello/world')
-            expect(output).toBe('hello-world')
-        })
-
-        test(`replaces all non-word characters with a dash`, async () => {
-            const output = utils.getSanitizedBranchName(
-                'refs/heads/hello/world-100%_ready,for.this!here:it"a)b(c{d}e'
-            )
-            expect(output).toBe('hello-world-100-_ready-for-this-here-it-a-b-c-d-e')
-        })
-
-        test(`removes multiple dashes in a row`, async () => {
-            const output = utils.getSanitizedBranchName(
-                'refs/heads/hello/my-very-weird_branch-100%%%-original'
-            )
-            expect(output).toBe('hello-my-very-weird_branch-100-original')
-        })
-
-        test(`caps the length of the sanitized name to 60 characters`, async () => {
-            const output = utils.getSanitizedBranchName(
-                'refs/heads/hello/my-very-weird_branch-100-original-whoooohoooooo-lets-do_it'
-            )
-            expect(output).toBe('hello-my-very-weird_branch-100-original-whoooohoooooo-lets-d')
         })
     })
 })

--- a/actions/utils.ts
+++ b/actions/utils.ts
@@ -102,28 +102,6 @@ export async function runAction(action: () => Promise<unknown>) {
 }
 
 /**
- * Retrieve and convert the current git branch name to a string that is safe
- * for use as a S3 file key and a URL segment
- * @returns branchName
- */
-export function getSanitizedBranchName(ref: string) {
-    const branchName = ref
-        .split('refs/heads/')
-        .pop()
-        ?.replace(/[^\w]/gi, '-') // replace all non-word characters with a "-"
-        .replace(/-{2,}/gi, '-') // get rid of multiple consecutive "-"
-        .toLowerCase()
-        .slice(0, 60)
-        .trim()
-
-    if (!branchName) {
-        throw new Error('Invalid context, could not calculate sanitized branch name')
-    }
-
-    return branchName
-}
-
-/**
  * Validate if the passed git commit hash is present on the current branch
  * @param commitHash - commit hash to validate
  * @returns isHeadAncestor

--- a/actions/yarn.lock
+++ b/actions/yarn.lock
@@ -2,12 +2,13 @@
 # yarn lockfile v1
 
 
-"@actions/core@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.9.0.tgz#20c1baac5d4bd2508ba1fc3e5f3fc4b8a80d4082"
-  integrity sha512-5pbM693Ih59ZdUhgk+fts+bUWTnIdHV3kwOSr+QIoFHMLg7Gzhwm0cifDY/AG68ekEJAkHnQVpcy4f6GjmzBCA==
+"@actions/core@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.9.1.tgz#97c0201b1f9856df4f7c3a375cdcdb0c2a2f750b"
+  integrity sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==
   dependencies:
     "@actions/http-client" "^2.0.1"
+    uuid "^8.3.2"
 
 "@actions/exec@1.1.1":
   version "1.1.1"
@@ -945,12 +946,12 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^28.1.6":
-  version "28.1.6"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.6.tgz#d6a9cdd38967d2d746861fb5be6b120e38284dd4"
-  integrity sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==
+"@types/jest@^28.1.7":
+  version "28.1.7"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-28.1.7.tgz#a680c5d05b69634c2d54a63cb106d7fb1adaba16"
+  integrity sha512-acDN4VHD40V24tgu0iC44jchXavRNVFXQ/E6Z5XNsswgoSO/4NgsXoEYmPUGookKldlZQyIpmrEXsHI9cA3ZTA==
   dependencies:
-    jest-matcher-utils "^28.0.0"
+    expect "^28.0.0"
     pretty-format "^28.0.0"
 
 "@types/node@*":
@@ -1397,7 +1398,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expect@^28.1.3:
+expect@^28.0.0, expect@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-28.1.3.tgz#90a7c1a124f1824133dd4533cce2d2bdcb6603ec"
   integrity sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==
@@ -1785,7 +1786,7 @@ jest-leak-detector@^28.1.3:
     jest-get-type "^28.0.2"
     pretty-format "^28.1.3"
 
-jest-matcher-utils@^28.0.0, jest-matcher-utils@^28.1.3:
+jest-matcher-utils@^28.1.3:
   version "28.1.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz#5a77f1c129dd5ba3b4d7fc20728806c78893146e"
   integrity sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==
@@ -2526,10 +2527,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-ts-jest@^28.0.7:
-  version "28.0.7"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.7.tgz#e18757a9e44693da9980a79127e5df5a98b37ac6"
-  integrity sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==
+ts-jest@^28.0.8:
+  version "28.0.8"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.8.tgz#cd204b8e7a2f78da32cf6c95c9a6165c5b99cc73"
+  integrity sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
@@ -2572,6 +2573,11 @@ update-browserslist-db@^1.0.4:
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
BREAKING CHANGE: The post preview url actions now takes a JSON definition of links to post

Refactors the `post-preview-urls` action to take a JSON array describing the links to post to the PR
Returns the hostname label used for deployment from the cursor deploy action 
Adjust reusable workflows to work with the above updates.